### PR TITLE
build(deps): Bump PHP and dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '38 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Data
 
-[![CI](https://github.com/JBZoo/Data/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Data/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Data/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Data?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Data/coverage.svg)](https://shepherd.dev/github/JBZoo/Data)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Data/level.svg)](https://shepherd.dev/github/JBZoo/Data)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/data/badge)](https://www.codefactor.io/repository/github/jbzoo/data/issues)    
+[![CI](https://github.com/JBZoo/Data/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Data/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Data/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Data?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Data/coverage.svg)](https://shepherd.dev/github/JBZoo/Data)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Data/level.svg)](https://shepherd.dev/github/JBZoo/Data)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/data/badge)](https://www.codefactor.io/repository/github/jbzoo/data/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/data/version)](https://packagist.org/packages/jbzoo/data/)    [![Total Downloads](https://poser.pugx.org/jbzoo/data/downloads)](https://packagist.org/packages/jbzoo/data/stats)    [![Dependents](https://poser.pugx.org/jbzoo/data/dependents)](https://packagist.org/packages/jbzoo/data/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/data)](https://github.com/JBZoo/Data/blob/master/LICENSE)
 
 
@@ -135,7 +135,7 @@ List of filters - [JBZoo/Utils/Filter](https://github.com/JBZoo/Utils/blob/maste
  * `float` - Smart converting to float
  * `digits` - Leaves only "0-9"
  * `alpha` - Leaves only "a-zA-Z"
- * `alphanum` - Combination of `digits` and `alpha` 
+ * `alphanum` - Combination of `digits` and `alpha`
  * `base64` - Returns only chars which are compatible with base64
  * `path` - Clean FS path
  * `trim` - Extend trim
@@ -279,13 +279,13 @@ a:7:{s:5:"empty";s:0:"";s:4:"zero";s:1:"0";s:6:"string";s:1:" ";s:3:"tag";s:42:"
 ## Summary benchmark info (execution time) PHP v7.4
 All benchmark tests are executing without xdebug and with a huge random array and 100.000 iterations.
 
-Benchmark tests based on the tool [phpbench/phpbench](https://github.com/phpbench/phpbench). See details [here](tests/phpbench).   
+Benchmark tests based on the tool [phpbench/phpbench](https://github.com/phpbench/phpbench). See details [here](tests/phpbench).
 
 Please, pay attention - `1μs = 1/1.000.000 of second!`
 
 **benchmark: CreateObject**
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchArrayObjectOrig | Native,ArrayObject | 3 | 100000 | 7.30μs | 0.01μs | 0.18% | 8,388,608b | 1.00x
 benchArrayObjectExtOrig | Native,ArrayObject,Extended | 3 | 100000 | 7.43μs | 0.05μs | 0.66% | 8,388,608b | 1.02x
 benchJson | JSON | 3 | 100000 | 7.55μs | 0.01μs | 0.15% | 8,388,608b | 1.03x
@@ -302,7 +302,7 @@ benchPhpArrayFunc | PhpArray,Func | 3 | 100000 | 7.75μs | 0.06μs | 0.72% | 8,3
 
 **benchmark: GetUndefinedValue**
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchArrayIsset | Native,Array,Undefined | 3 | 1000000 | 0.04μs | 0.00μs | 1.48% | 8,388,608b | 1.00x
 benchDataOffsetGet | Data,Undefined | 3 | 1000000 | 0.11μs | 0.00μs | 0.41% | 8,388,608b | 2.88x
 benchDataGet | Data,Undefined | 3 | 1000000 | 0.14μs | 0.00μs | 0.39% | 8,388,608b | 3.56x
@@ -315,7 +315,7 @@ benchDataFindInner | Data,Undefined | 3 | 1000000 | 0.41μs | 0.00μs | 0.14% | 
 
 **benchmark: GetValue**
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchArrayRegular | Native,Array | 3 | 1000000 | 0.04μs | 0.00μs | 5.02% | 8,388,608b | 1.00x
 benchArrayRegularMuted | Native,Array | 3 | 1000000 | 0.04μs | 0.00μs | 1.40% | 8,388,608b | 1.06x
 benchArrayIsset | Native,Array | 3 | 1000000 | 0.04μs | 0.00μs | 2.04% | 8,388,608b | 1.07x
@@ -331,7 +331,7 @@ benchDataFind | Data | 3 | 1000000 | 0.35μs | 0.00μs | 0.65% | 8,388,608b | 8.
 
 **benchmark: GetValueInner**
 subject | groups | its | revs | mean | stdev | rstdev | mem_real | diff
- --- | --- | --- | --- | --- | --- | --- | --- | --- 
+ --- | --- | --- | --- | --- | --- | --- | --- | ---
 benchArrayRegular | Native,Array | 3 | 1000000 | 0.05μs | 0.00μs | 0.23% | 8,388,608b | 1.00x
 benchArrayRegularMuted | Native,Array | 3 | 1000000 | 0.06μs | 0.00μs | 0.86% | 8,388,608b | 1.06x
 benchArrayIsset | Native,Array | 3 | 1000000 | 0.06μs | 0.00μs | 0.27% | 8,388,608b | 1.08x

--- a/composer.json
+++ b/composer.json
@@ -27,25 +27,25 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"      : "^8.1",
+        "php"      : "^8.2",
         "ext-json" : "*"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev"         : "^7.1",
-        "jbzoo/utils"               : "^7.1.1",
-        "symfony/yaml"              : ">=6.4",
+        "jbzoo/toolbox-dev"         : "^7.2",
+        "jbzoo/utils"               : "^7.2.2",
+        "symfony/yaml"              : ">=7.3.3",
 
-        "symfony/polyfill-ctype"    : ">=1.28.0",
-        "symfony/polyfill-mbstring" : ">=1.28.0",
-        "symfony/polyfill-php73"    : ">=1.28.0",
-        "symfony/polyfill-php80"    : ">=1.28.0",
-        "symfony/polyfill-php81"    : ">=1.28.0"
+        "symfony/polyfill-ctype"    : ">=1.33.0",
+        "symfony/polyfill-mbstring" : ">=1.33.0",
+        "symfony/polyfill-php73"    : ">=1.33.0",
+        "symfony/polyfill-php80"    : ">=1.33.0",
+        "symfony/polyfill-php81"    : ">=1.33.0"
     },
 
     "suggest"           : {
-        "symfony/yaml" : ">=6.4",
-        "jbzoo/utils"  : ">=7.1"
+        "symfony/yaml" : ">=7.3",
+        "jbzoo/utils"  : ">=7.2"
     },
 
     "autoload"          : {

--- a/src/AbstractData.php
+++ b/src/AbstractData.php
@@ -21,6 +21,7 @@ use JBZoo\Utils\Filter;
 
 /**
  * @psalm-suppress MissingTemplateParam
+ * @phpstan-ignore missingType.generics
  */
 abstract class AbstractData extends \ArrayObject
 {
@@ -200,7 +201,7 @@ abstract class AbstractData extends \ArrayObject
      * Find a value also in nested arrays/objects.
      * @param mixed $needle The value to search for
      */
-    public function search(mixed $needle): null|bool|float|int|string
+    public function search(mixed $needle): bool|float|int|string|null
     {
         $aIterator = new \RecursiveArrayIterator($this->getArrayCopy());
         $iterator  = new \RecursiveIteratorIterator($aIterator);
@@ -263,6 +264,7 @@ abstract class AbstractData extends \ArrayObject
         }
 
         /** @noinspection TypeUnsafeComparisonInspection */
+        /** @phpstan-ignore equal.notAllowed */
         return $value == $compareWith;
     }
 
@@ -305,6 +307,9 @@ abstract class AbstractData extends \ArrayObject
         return \count($arrayCount) > 0;
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArrayOffset
+     */
     private static function setNestedValue(array &$array, array $keys, mixed $value): void
     {
         $key = \array_shift($keys);

--- a/src/AliasesTrait.php
+++ b/src/AliasesTrait.php
@@ -120,7 +120,7 @@ trait AliasesTrait
      * @psalm-suppress UnsafeInstantiation
      * @psalm-suppress ImplicitToStringCast
      */
-    public function getSelfNull(string $key, null|array|self $default = null): ?self
+    public function getSelfNull(string $key, array|self|null $default = null): ?self
     {
         if (!$this->has($key)) {
             // @phpstan-ignore-next-line

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\Data;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -587,7 +587,7 @@ class DataTest extends PHPUnit
                 'null'            => 'null',
                 'array_empty'     => [],
                 'array_not_empty' => [123 => 'string'],
-                'objects'         => '\\stdClass',
+                'objects'         => '\stdClass',
                 'sub'             => [
                     'sub'     => 'string',
                     'sub.sub' => 'string',
@@ -599,7 +599,7 @@ class DataTest extends PHPUnit
                         'sub'   => ['key-sub' => 'string'],
                     ],
                 ],
-                'data'   => '\\JBZoo\\Data\\Data',
+                'data'   => '\JBZoo\Data\Data',
                 'nested' => [
                     'value-1' => 'string',
                     'value-2' => 'string',


### PR DESCRIPTION
- Update minimum PHP version to 8.2.
- Add PHP 8.4 to CI matrix, removing PHP 8.1.
- Update `jbzoo/toolbox-dev`, `jbzoo/utils`, and `symfony/*` dependencies.
- Remove scheduled CI workflow run.
- Update `actions/upload-artifact` to v4.
- Add `final` keyword to `Exception` class.
- Add static analysis ignore annotations and fix namespace usage in tests.