### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,11 +68,12 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ make report-phploc      # Lines of code statistics
 ## Development Standards
 
 ### PHP Requirements
-- PHP 8.2+ required
+- PHP 8.3+ required
 - Strict types enabled (`declare(strict_types=1)`)
 - PSR-12 coding standard
 - Full type hints required
@@ -105,8 +105,8 @@ The library includes comprehensive benchmarks comparing:
 - `ext-json: *`
 
 ### Development/Optional
-- `jbzoo/toolbox-dev: ^7.2` - Development tooling
-- `jbzoo/utils: ^7.2.2` - Utility functions for filtering
+- `jbzoo/toolbox-dev: ^8.0` - Development tooling
+- `jbzoo/utils: ^8.0` - Utility functions for filtering
 - `symfony/yaml: >=7.3.3` - YAML parsing support
 
 ## Test Data and Fixtures

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Data
 
-[![CI](https://github.com/JBZoo/Data/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Data/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Data/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Data?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Data/coverage.svg)](https://shepherd.dev/github/JBZoo/Data)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Data/level.svg)](https://shepherd.dev/github/JBZoo/Data)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/data/badge)](https://www.codefactor.io/repository/github/jbzoo/data/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/data/version)](https://packagist.org/packages/jbzoo/data/)    [![Total Downloads](https://poser.pugx.org/jbzoo/data/downloads)](https://packagist.org/packages/jbzoo/data/stats)    [![Dependents](https://poser.pugx.org/jbzoo/data/dependents)](https://packagist.org/packages/jbzoo/data/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/data)](https://github.com/JBZoo/Data/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Data/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Data/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Data/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Data?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Data/coverage.svg)](https://shepherd.dev/github/JBZoo/Data)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Data/level.svg)](https://shepherd.dev/github/JBZoo/Data)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/data/badge)](https://www.codefactor.io/repository/github/jbzoo/data/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/data/version)](https://packagist.org/packages/jbzoo/data/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/data/downloads)](https://packagist.org/packages/jbzoo/data/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/data/dependents)](https://packagist.org/packages/jbzoo/data/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/data)](https://github.com/JBZoo/Data/blob/master/LICENSE)
 
 
 An extended version of the [ArrayObject](http://php.net/manual/en/class.arrayobject.php) object for working with system settings or just for working with data arrays.

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"      : "^8.2",
+        "php"      : "^8.3",
         "ext-json" : "*"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev"         : "^7.2",
-        "jbzoo/utils"               : "^7.2.2",
+        "jbzoo/toolbox-dev"         : "^8.0",
+        "jbzoo/utils"               : "^8.0",
         "symfony/yaml"              : ">=7.3.3",
 
         "symfony/polyfill-ctype"    : ">=1.33.0",
@@ -67,7 +67,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,12 +10,7 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Data
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
+<phpunit bootstrap="tests/autoload.php"
          executionOrder="random"
          processIsolation="false"
          stopOnError="false"
@@ -23,14 +18,8 @@
          stopOnIncomplete="false"
          stopOnSkipped="false"
          stopOnRisky="false"
-         verbose="false"
-         colors="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         colors="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -47,4 +36,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/AbstractData.php
+++ b/src/AbstractData.php
@@ -27,7 +27,7 @@ abstract class AbstractData extends \ArrayObject
 {
     use AliasesTrait;
 
-    public const LE = "\n";
+    public const string LE = "\n";
 
     /**
      * Utility Method to unserialize the given data.

--- a/src/JSON.php
+++ b/src/JSON.php
@@ -26,7 +26,7 @@ final class JSON extends AbstractData
 
     protected function encode(array $data): string
     {
-        $result = \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT | \JSON_BIGINT_AS_STRING);
+        $result = \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT);
 
         // @phpstan-ignore-next-line
         return $result ?: '';

--- a/tests/DataYmlTest.php
+++ b/tests/DataYmlTest.php
@@ -24,18 +24,27 @@ class DataYmlTest extends PHPUnit
 
     public function testFile(): void
     {
-        $data      = new Yml($this->testFile);
-        $dataValid = openFile($this->testFile);
+        $data     = new Yml($this->testFile);
+        $reParsed = new Yml((string)$data);
 
-        is($dataValid, (string)$data);
+        // symfony/yaml's dump formatting changed across majors (7.x block vs 8.x inline sequences),
+        // so assert the DATA survives a dump -> parse round-trip instead of matching the source file
+        // byte-for-byte (which is brittle across the PHP/symfony matrix).
+        isSame($data->getArrayCopy(), $reParsed->getArrayCopy());
+
+        // Concrete fixture values (tests/resource/data.yml) guard against a SYMMETRIC parse/dump loss
+        // that a pure round-trip cannot see — a bug dropping the same field on both sides still
+        // compares equal. Assert both the loaded and the reparsed value.
+        isSame(34843, $data->get('invoice'));
+        isSame('BL4438H', $reParsed->find('product.1.sku'));
     }
 
     public function testString(): void
     {
-        $data      = new Yml(openFile($this->testFile));
-        $dataValid = openFile($this->testFile);
+        $data     = new Yml(openFile($this->testFile));
+        $reParsed = new Yml((string)$data);
 
-        is($dataValid, (string)$data);
+        isSame($data->getArrayCopy(), $reParsed->getArrayCopy());
     }
 
     public function testPropsVisible(): void


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven; no public API signature changes).

### Changed (BC — packaging major 8.0)
- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0` (lock-step major).
- Public constant `AbstractData::LE` is now typed (`public const string`). An external subclass overriding it must declare a compatible type.
- `JSON` output no longer HEX-escapes `&` (removed a decode-only flag whose bit collided with `JSON_HEX_AMP`). Add your own escaping if embedding into HTML/XML.
